### PR TITLE
Call the dataset API instead of the import API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dp-observation-importer
 | OBSERVATION_CONSUMER_GROUP | "dp-observation-importer"        | The Kafka consumer group to consume observation extracted events from
 | OBSERVATION_CONSUMER_TOPIC | "observation-extracted"          | The Kafka topic to consume observation extracted events from
 | DATABASE_ADDRESS           | "bolt://localhost:7687"          | The address of the database
-| IMPORT_API_URL             | "http://localhost:21800"         | The URL of the import API
+| DATASET_API_URL            | "http://localhost:21800"         | The URL of the dataset API
 | BATCH_SIZE                 | 1000                             | The number of messages to process in each batch if the time out has not been reached
 | BATCH_WAIT_TIME            | 200ms                            | The duration to wait before processing a partially full batch of messages
 | ERROR_PRODUCER_TOPIC       | "import-error"                   | The Kafka topic to send the error messages to

--- a/cmd/dp-observation-importer/main.go
+++ b/cmd/dp-observation-importer/main.go
@@ -34,7 +34,7 @@ func main() {
 		"topics":                     []string{config.ObservationConsumerTopic, config.ErrorProducerTopic, config.ResultProducerTopic},
 		"brokers":                    config.KafkaAddr,
 		"bind_addr":                  config.BindAddr,
-		"import_api_url":             config.ImportAPIURL,
+		"dataset_api_url":             config.DatasetAPIURL,
 		"observation_consumer_group": config.ObservationConsumerGroup,
 		"cache_ttl":                  config.CacheTTL,
 		"batch_size":                 config.BatchSize,
@@ -90,9 +90,9 @@ func main() {
 	// when errors occur - we send a message on an error topic.
 	errorHandler := errors.NewKafkaHandler(kafkaErrorProducer)
 
-	// objects to get dimension data - via the import API + cached locally in memory.
+	// objects to get dimension data - via the dataset API + cached locally in memory.
 	httpClient := http.Client{Timeout: time.Second * 15}
-	dimensionStore := dimension.NewStore(config.ImportAPIURL, &httpClient)
+	dimensionStore := dimension.NewStore(config.DatasetAPIURL, &httpClient)
 	dimensionOrderCache := dimension.NewOrderCache(dimensionStore, config.CacheTTL)
 	dimensionIDCache := dimension.NewIDCache(dimensionStore, config.CacheTTL)
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	ObservationConsumerGroup string        `envconfig:"OBSERVATION_CONSUMER_GROUP"`
 	ObservationConsumerTopic string        `envconfig:"OBSERVATION_CONSUMER_TOPIC"`
 	DatabaseAddress          string        `envconfig:"DATABASE_ADDRESS"`
-	ImportAPIURL             string        `envconfig:"IMPORT_API_URL"`
+	DatasetAPIURL            string        `envconfig:"DATASET_API_URL"`
 	BatchSize                int           `envconfig:"BATCH_SIZE"`
 	BatchWaitTime            time.Duration `envconfig:"BATCH_WAIT_TIME_MS"`
 	ErrorProducerTopic       string        `envconfig:"ERROR_PRODUCER_TOPIC"`
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 		ObservationConsumerGroup: "observation-extracted",
 		ObservationConsumerTopic: "observation-extracted",
 		DatabaseAddress:          "bolt://localhost:7687",
-		ImportAPIURL:             "http://localhost:21800",
+		DatasetAPIURL:            "http://localhost:22000",
 		BatchSize:                1000,
 		BatchWaitTime:            time.Millisecond * 200,
 		ErrorProducerTopic:       "import-error",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.ObservationConsumerGroup, ShouldEqual, "observation-extracted")
 				So(cfg.ObservationConsumerTopic, ShouldEqual, "observation-extracted")
 				So(cfg.DatabaseAddress, ShouldEqual, "bolt://localhost:7687")
-				So(cfg.ImportAPIURL, ShouldEqual, "http://localhost:21800")
+				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
 				So(cfg.BatchSize, ShouldEqual, 1000)
 				So(cfg.BatchWaitTime, ShouldEqual, time.Millisecond*200)
 				So(cfg.ErrorProducerTopic, ShouldEqual, "import-error")

--- a/dimension/dimensiontest/dataset_api.go
+++ b/dimension/dimensiontest/dataset_api.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 )
 
-// MockImportAPI provides mock functionality for the import API.
-type MockImportAPI struct {
+// MockDatasetAPI provides mock functionality for the dataset API.
+type MockDatasetAPI struct {
 	FailRequest bool
 	Data        string
 }
 
 // Do returns a mock HTTP response for the given request.
-func (i MockImportAPI) Do(req *http.Request) (*http.Response, error) {
+func (i MockDatasetAPI) Do(req *http.Request) (*http.Response, error) {
 	if i.FailRequest {
 		return nil, fmt.Errorf("Failed to process the request")
 	}

--- a/dimension/store.go
+++ b/dimension/store.go
@@ -7,17 +7,17 @@ import (
 	"net/http"
 )
 
-// ErrParseAPIResponse used when the import API response fails to be parsed.
-var ErrParseAPIResponse = errors.New("failed to parse import api response")
+// ErrParseAPIResponse used when the dataset API response fails to be parsed.
+var ErrParseAPIResponse = errors.New("failed to parse dataset api response")
 
-// ErrInstanceNotFound returned when the given instance ID is not found in the import API.
-var ErrInstanceNotFound = errors.New("import api failed to find instance")
+// ErrInstanceNotFound returned when the given instance ID is not found in the dataset API.
+var ErrInstanceNotFound = errors.New("dataset api failed to find instance")
 
-// ErrInternalError returned when an unrecognised internal error occurs in the import API.
-var ErrInternalError = errors.New("internal error from the import api")
+// ErrInternalError returned when an unrecognised internal error occurs in the dataset API.
+var ErrInternalError = errors.New("internal error from the dataset api")
 
-// ImportAPIClient an interface used to access the import api
-type ImportAPIClient interface {
+// DatasetAPIClient an interface used to access the dataset api
+type DatasetAPIClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
@@ -25,7 +25,7 @@ type csvHeaders struct {
 	Headers []string `json:"headers"`
 }
 
-// Dimension which has been cached from the import api
+// Dimension which has been cached from the dataset api
 type Dimension struct {
 	DimensionName string `json:"dimension_id"`
 	Value         string `json:"value"`
@@ -34,21 +34,21 @@ type Dimension struct {
 
 // Store represents the storage of dimension data.
 type Store struct {
-	importAPIURL    string
-	importAPIClient ImportAPIClient
+	datasetAPIURL    string
+	datasetAPIClient DatasetAPIClient
 }
 
 // NewStore returns a new instance of a dimension store.
-func NewStore(importAPIURL string, client ImportAPIClient) *Store {
+func NewStore(datasetAPIURL string, client DatasetAPIClient) *Store {
 	return &Store{
-		importAPIURL:    importAPIURL,
-		importAPIClient: client,
+		datasetAPIURL:    datasetAPIURL,
+		datasetAPIClient: client,
 	}
 }
 
 // GetOrder returns list of dimension names in the order they are stored in the input file.
 func (store *Store) GetOrder(instanceID string) ([]string, error) {
-	url := store.importAPIURL + "/instances/" + instanceID
+	url := store.datasetAPIURL + "/instances/" + instanceID
 	request, requestErr := http.NewRequest("GET", url, nil)
 	if requestErr != nil {
 		return nil, requestErr
@@ -68,7 +68,7 @@ func (store *Store) GetOrder(instanceID string) ([]string, error) {
 // GetIDs returns all dimensions for a given instanceID
 func (store *Store) GetIDs(instanceID string) (map[string]string, error) {
 
-	url := store.importAPIURL + "/instances/" + instanceID + "/dimensions"
+	url := store.datasetAPIURL + "/instances/" + instanceID + "/dimensions"
 	request, requestErr := http.NewRequest("GET", url, nil)
 	if requestErr != nil {
 		return nil, requestErr
@@ -92,7 +92,7 @@ func (store *Store) GetIDs(instanceID string) (map[string]string, error) {
 }
 
 func (store *Store) processRequest(r *http.Request, instanceID string) ([]byte, error) {
-	response, responseError := store.importAPIClient.Do(r)
+	response, responseError := store.datasetAPIClient.Do(r)
 	if responseError != nil {
 		return nil, responseError
 	}

--- a/dimension/store_test.go
+++ b/dimension/store_test.go
@@ -9,7 +9,7 @@ import (
 func TestStore_GetOrder(t *testing.T) {
 
 	data := `{"headers": ["V4_1","Data_Marking","Time_codelist"]}`
-	dataStore := NewStore("http://localhost:288100", dimensiontest.MockImportAPI{Data: data})
+	dataStore := NewStore("http://localhost:288100", dimensiontest.MockDatasetAPI{Data: data})
 
 	Convey("Given a valid instanceId", t, func() {
 
@@ -27,7 +27,7 @@ func TestStore_GetOrder(t *testing.T) {
 
 func TestStore_GetOrderReturnAnError(t *testing.T) {
 
-	dataStore := NewStore("http://unknown-url:288100", dimensiontest.MockImportAPI{FailRequest: true})
+	dataStore := NewStore("http://unknown-url:288100", dimensiontest.MockDatasetAPI{FailRequest: true})
 
 	Convey("Given a invalid URL", t, func() {
 
@@ -43,7 +43,7 @@ func TestStore_GetOrderReturnAnError(t *testing.T) {
 
 func TestIDCache_GetIDs(t *testing.T) {
 	data := `[{ "dimension_name": "6_Year_1997","value": "1997","node_id": "123"}]`
-	dataStore := NewStore("http://localhost:288100", dimensiontest.MockImportAPI{Data: data})
+	dataStore := NewStore("http://localhost:288100", dimensiontest.MockDatasetAPI{Data: data})
 	Convey("Given a valid instance id", t, func() {
 		Convey("When the client api is called ", func() {
 			Convey("A list of dimensions are returned", func() {


### PR DESCRIPTION
### What

Call the dataset API instead of the import API for the instance related endpoints.

Waiting on the dataset API changes to be complete before integration testing the import services against it.

### How to review

Review code changes

### Who can review

You 👍 