### PR TITLE
Do not kill the app when a query execution error occurs

### DIFF
--- a/observation/store.go
+++ b/observation/store.go
@@ -33,7 +33,7 @@ type DBPool interface {
 }
 
 //go:generate moq -out observationtest/db_conn.go -pkg observationtest . DBConnection
-// The follow variable is only used to generate mocked bolt connections
+// DBConnection is only used to generate mocked bolt connections
 type DBConnection bolt.Conn
 
 // NewStore returns a new Observation store instance that uses the given dimension ID cache and db connection.
@@ -95,7 +95,7 @@ func (store *Store) SaveAll(observations []*Observation) ([]*Result, error) {
 			for instanceID := range instanceObservations {
 				store.reportError(instanceID, "observation batch insert failed", err)
 			}
-			return nil, err
+			continue
 		}
 
 		rowsAffected, err := queryResult.RowsAffected()

--- a/observation/store.go
+++ b/observation/store.go
@@ -95,6 +95,11 @@ func (store *Store) SaveAll(observations []*Observation) ([]*Result, error) {
 			for instanceID := range instanceObservations {
 				store.reportError(instanceID, "observation batch insert failed", err)
 			}
+
+			// todo: add retry logic and identify fatal errors that should be returned.
+			// any error will currently be sent to the reporter and mark the import as failed
+			// we do not return the error as we want the message to be consumed.
+			// returning an error causes the service to shutdown and not consume the message.
 			continue
 		}
 

--- a/observation/store_test.go
+++ b/observation/store_test.go
@@ -113,9 +113,9 @@ func TestStore_SaveAllExecError(t *testing.T) {
 		Convey("When dBConnection.Exec returns an error", func() {
 			results, err := store.SaveAll([]*observation.Observation{inputObservation})
 
-			Convey("Then no results and the expected error are returned", func() {
-				So(results, ShouldBeNil)
-				So(err, ShouldResemble, mockError)
+			Convey("Then an empty set of results and nil error are returned", func() {
+				So(len(results), ShouldEqual, 0)
+				So(err, ShouldBeNil)
 			})
 
 			Convey("And the error reporter is called once for each instance in the failed batch", func() {

--- a/observation/store_test.go
+++ b/observation/store_test.go
@@ -115,6 +115,7 @@ func TestStore_SaveAllExecError(t *testing.T) {
 
 			Convey("Then an empty set of results and nil error are returned", func() {
 				So(len(results), ShouldEqual, 0)
+				So(len(conn.ExecNeoCalls()), ShouldEqual, 1)
 				So(err, ShouldBeNil)
 			})
 


### PR DESCRIPTION
### What

A query exectution error would be returned from the function, even
though it had been handled by the error reporter. If an error occurs it
should report the error and continue instead of letting the error bubble
up and kill the app.

The problem can be replicated by importing a CSV file with the following content:

```
V4_0
<script>alert(123)</script>
```

### How to review

Review code and test with given example

### Who can review

You 👍 :trollface: 
