### PR TITLE
Only commit the last message in the batch when processed

### DIFF
--- a/event/consumer.go
+++ b/event/consumer.go
@@ -13,7 +13,7 @@ import (
 // MessageConsumer provides a generic interface for consuming []byte messages (from Kafka)
 type MessageConsumer interface {
 	Channels() *kafka.ConsumerGroupChannels
-	CommitAndRelease(msg kafka.Message)
+	Release()
 }
 
 // Handler represents a handler for processing a batch of events.
@@ -59,7 +59,7 @@ func (consumer *Consumer) Consume(messageConsumer MessageConsumer,
 				ctx := context.Background()
 
 				AddMessageToBatch(ctx, batch, msg, handler, errChan)
-				messageConsumer.CommitAndRelease(msg)
+				messageConsumer.Release()
 
 			case <-time.After(batchWaitTime):
 				if batch.IsEmpty() {

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -27,10 +27,14 @@ func TestConsume(t *testing.T) {
 
 			go consumer.Consume(messageConsumer, batchSize, eventHandler, batchWaitTime, exit)
 
-			message := kafkatest.NewMessage([]byte(marshal(expectedEvent)), 0)
+			message := kafkatest.NewMessage(marshal(expectedEvent), 0)
 			messageConsumer.Channels().Upstream <- message
 
 			<-eventHandler.EventUpdated
+
+			Convey("The consumer is released to consume the next message", func() {
+				So(len(messageConsumer.ReleaseCalls()), ShouldEqual, 1)
+			})
 
 			Convey("The expected event is sent to the handler", func() {
 				So(len(eventHandler.Events), ShouldEqual, 1)
@@ -84,11 +88,15 @@ func TestConsume_Timeout(t *testing.T) {
 
 			go consumer.Consume(messageConsumer, batchSize, eventHandler, batchWaitTime, exit)
 
-			message := kafkatest.NewMessage([]byte(marshal(expectedEvent)), 0)
+			message := kafkatest.NewMessage(marshal(expectedEvent), 0)
 			messageConsumer.Channels().Upstream <- message
 			<-messageConsumer.Channels().UpstreamDone
 
 			<-eventHandler.EventUpdated
+
+			Convey("The consumer is released to consume the next message", func() {
+				So(len(messageConsumer.ReleaseCalls()), ShouldEqual, 1)
+			})
 
 			Convey("The consumer timeout is hit and the single event is sent to the handler anyway", func() {
 				So(len(eventHandler.Events), ShouldEqual, 1)
@@ -123,11 +131,15 @@ func TestConsume_DelayedMessages(t *testing.T) {
 
 			go consumer.Consume(messageConsumer, batchSize, eventHandler, batchWaitTime, exit)
 
-			message := kafkatest.NewMessage([]byte(marshal(expectedEvent)), 0)
+			message := kafkatest.NewMessage(marshal(expectedEvent), 0)
 			go SendMessagesWithDelay(messageConsumer, []*kafkatest.Message{message, message, message}, messageDelay)
 
 			// wait for event updated channel to receive event from the mock event handler
 			<-eventHandler.EventUpdated
+
+			Convey("The consumer is released to consume the next message", func() {
+				So(len(messageConsumer.ReleaseCalls()), ShouldEqual, 3)
+			})
 
 			Convey("The expected events are sent to the handler in one batch - i.e. the timeout is not hit", func() {
 				So(len(eventHandler.Events), ShouldEqual, 3)


### PR DESCRIPTION
### What
Only commit the last message in the batch when processed
- Messages are currently committed as they are read. If the batch fails then all messages read so far will not be re-consumed.
- add test coverage for calling release on the consumer

### How to review
- Review changes

### Who can review
Anyone
