### PR TITLE
Upgrade dp-graph to v2.1.0

### DIFF
--- a/cmd/dp-observation-importer/main.go
+++ b/cmd/dp-observation-importer/main.go
@@ -111,8 +111,13 @@ func run(ctx context.Context) error {
 	// Get graphdb connection for observation store
 	graphDB, err := serviceList.GetGraphDB(ctx)
 	if err != nil {
-		log.Event(ctx, "failed to instantiate neo4j observation store", log.FATAL, log.Error(err))
+		log.Event(ctx, "failed to instantiate graph observation store", log.FATAL, log.Error(err))
 		return err
+	}
+
+	var graphErrorConsumer *graph.ErrorConsumer
+	if serviceList.Graph {
+		graphErrorConsumer = graph.NewLoggingErrorConsumer(ctx, graphDB.Errors)
 	}
 
 	datasetClient := dataset.NewAPIClient(cfg.DatasetAPIURL)
@@ -214,36 +219,43 @@ func run(ctx context.Context) error {
 
 		// If observation imported kafka producer exists, close it
 		if serviceList.ObservationsImportedProducer {
-			log.Event(shutdownContext, "closing observation imported kafka producer", log.INFO, log.Data{"producer": "DimensionExtracted"})
+			log.Event(shutdownContext, "closing observation imported kafka producer", log.INFO)
 			observationsImportedProducer.Close(shutdownContext)
-			log.Event(shutdownContext, "closed observation imported kafka producer", log.INFO, log.Data{"producer": "DimensionExtracted"})
+			log.Event(shutdownContext, "closed observation imported kafka producer", log.INFO)
 		}
 
 		// If observation imported error kafka producer exists, close it
 		if serviceList.ObservationsImportedErrProducer {
-			log.Event(shutdownContext, "closing observation imported error kafka producer", log.INFO, log.Data{"producer": "DimensionExtracted"})
+			log.Event(shutdownContext, "closing observation imported error kafka producer", log.INFO)
 			observationsImportedErrProducer.Close(shutdownContext)
-			log.Event(shutdownContext, "closed observation imported error kafka producer", log.INFO, log.Data{"producer": "DimensionExtracted"})
+			log.Event(shutdownContext, "closed observation imported error kafka producer", log.INFO)
 		}
 
 		// Attempting to close event consumer
 		log.Event(shutdownContext, "closing event wrapper", log.INFO)
 		eventConsumer.Close(shutdownContext)
-		log.Event(shutdownContext, "closing event wrapper", log.INFO)
+		log.Event(shutdownContext, "closed event wrapper", log.INFO)
 
 		// If kafka consumer exists, close it.
 		if serviceList.Consumer {
-			log.Event(shutdownContext, "closing kafka consumer", log.INFO, log.Data{"consumer": "SyncConsumerGroup"})
+			log.Event(shutdownContext, "closing kafka consumer", log.INFO)
 			syncConsumerGroup.Close(shutdownContext)
-			log.Event(shutdownContext, "closed kafka consumer", log.INFO, log.Data{"consumer": "SyncConsumerGroup"})
+			log.Event(shutdownContext, "closed kafka consumer", log.INFO)
 		}
 
 		if serviceList.Graph {
+			log.Event(ctx, "closing graph db", log.INFO)
 			err = graphDB.Close(ctx)
 			if err != nil {
 				log.Event(ctx, "failed to close graph db", log.ERROR, log.Error(err))
 				hasShutdownError = true
 			}
+			err = graphErrorConsumer.Close(ctx)
+			if err != nil {
+				log.Event(ctx, "failed to close graph db error consumer", log.ERROR, log.Error(err))
+				hasShutdownError = true
+			}
+			log.Event(ctx, "closed graph db", log.INFO)
 		}
 
 		if !hasShutdownError {
@@ -301,7 +313,7 @@ func registerCheckers(ctx context.Context, hc *healthcheck.HealthCheck,
 	}
 
 	if hasErrors {
-		return errors.New("Error(s) registering checkers for healthcheck")
+		return errors.New("error registering checkers for health check")
 	}
 	return nil
 }

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -13,7 +13,7 @@ import (
 // MessageConsumer provides a generic interface for consuming []byte messages (from Kafka)
 type MessageConsumer interface {
 	Channels() *kafka.ConsumerGroupChannels
-	Release()
+	CommitAndRelease(msg kafka.Message)
 }
 
 // Handler represents a handler for processing a batch of events.
@@ -59,7 +59,7 @@ func (consumer *Consumer) Consume(messageConsumer MessageConsumer,
 				ctx := context.Background()
 
 				AddMessageToBatch(ctx, batch, msg, handler, errChan)
-				messageConsumer.Release()
+				messageConsumer.CommitAndRelease(msg)
 
 			case <-time.After(batchWaitTime):
 				if batch.IsEmpty() {

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -27,14 +27,10 @@ func TestConsume(t *testing.T) {
 
 			go consumer.Consume(messageConsumer, batchSize, eventHandler, batchWaitTime, exit)
 
-			message := kafkatest.NewMessage(marshal(expectedEvent), 0)
+			message := kafkatest.NewMessage([]byte(marshal(expectedEvent)), 0)
 			messageConsumer.Channels().Upstream <- message
 
 			<-eventHandler.EventUpdated
-
-			Convey("The consumer is released to consume the next message", func() {
-				So(len(messageConsumer.ReleaseCalls()), ShouldEqual, 1)
-			})
 
 			Convey("The expected event is sent to the handler", func() {
 				So(len(eventHandler.Events), ShouldEqual, 1)
@@ -88,15 +84,11 @@ func TestConsume_Timeout(t *testing.T) {
 
 			go consumer.Consume(messageConsumer, batchSize, eventHandler, batchWaitTime, exit)
 
-			message := kafkatest.NewMessage(marshal(expectedEvent), 0)
+			message := kafkatest.NewMessage([]byte(marshal(expectedEvent)), 0)
 			messageConsumer.Channels().Upstream <- message
 			<-messageConsumer.Channels().UpstreamDone
 
 			<-eventHandler.EventUpdated
-
-			Convey("The consumer is released to consume the next message", func() {
-				So(len(messageConsumer.ReleaseCalls()), ShouldEqual, 1)
-			})
 
 			Convey("The consumer timeout is hit and the single event is sent to the handler anyway", func() {
 				So(len(eventHandler.Events), ShouldEqual, 1)
@@ -131,15 +123,11 @@ func TestConsume_DelayedMessages(t *testing.T) {
 
 			go consumer.Consume(messageConsumer, batchSize, eventHandler, batchWaitTime, exit)
 
-			message := kafkatest.NewMessage(marshal(expectedEvent), 0)
+			message := kafkatest.NewMessage([]byte(marshal(expectedEvent)), 0)
 			go SendMessagesWithDelay(messageConsumer, []*kafkatest.Message{message, message, message}, messageDelay)
 
 			// wait for event updated channel to receive event from the mock event handler
 			<-eventHandler.EventUpdated
-
-			Convey("The consumer is released to consume the next message", func() {
-				So(len(messageConsumer.ReleaseCalls()), ShouldEqual, 3)
-			})
 
 			Convey("The expected events are sent to the handler in one batch - i.e. the timeout is not hit", func() {
 				So(len(eventHandler.Events), ShouldEqual, 3)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.7.0
-	github.com/ONSdigital/dp-graph/v2 v2.0.8
+	github.com/ONSdigital/dp-graph/v2 v2.1.0
 	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/dp-kafka v1.1.5
 	github.com/ONSdigital/dp-reporter-client v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/ONSdigital/dp-api-clients-go v1.7.0/go.mod h1:SM0b/NXDWndJ9EulmAGdfDY
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-graph/v2 v2.0.8 h1:Yah1pavVB/5G6dLZHMWxr6zgYrQet+p5ifMvqrFiQPc=
 github.com/ONSdigital/dp-graph/v2 v2.0.8/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
+github.com/ONSdigital/dp-graph/v2 v2.1.0 h1:yRFti9LgWtYUjr60b83aObHKLpLROg3GaT+jItz1988=
+github.com/ONSdigital/dp-graph/v2 v2.1.0/go.mod h1:6C59rOY0qBKblczkQrJZZKa8ZLR3yKkyunSCeIUavtU=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
@@ -31,6 +33,8 @@ github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
 github.com/ONSdigital/gremgo-neptune v0.0.0-20190806135047-c3c614e5b650 h1:GmVUMOd+k7Czv87P7vJ1QTpws9THtzmCFX3z/BlKd0I=
 github.com/ONSdigital/gremgo-neptune v0.0.0-20190806135047-c3c614e5b650/go.mod h1:oYyEo2KY54bzMSkdUpP0ouombGyaTN+P4ckKTuo+bog=
+github.com/ONSdigital/gremgo-neptune v1.0.0 h1:l0Pizt2goXK5oCFeqs2sOkosZbF4sva0RpcR150VvNE=
+github.com/ONSdigital/gremgo-neptune v1.0.0/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
 github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=


### PR DESCRIPTION
### What
Upgrade dp-graph to v2.1.0
- Use error-consumer to ensure errors from the graph DB are logged.
- Fix for quotes around observation values in Gremlin queries
- Fixed up some log messages. Some wrong values and excess log data.
- Revert previous commit to only commit the last message in the batch when processed
  - After this change messages are being read but not committed, hence the revert.

### How to review
Review changes

### Who can review
Anyone
